### PR TITLE
chore: update functions to match latest

### DIFF
--- a/interactions/rubberduck-channel/delete.c
+++ b/interactions/rubberduck-channel/delete.c
@@ -19,7 +19,7 @@ done_delete_channel(struct discord *cogbot,
     /* remove rubberduck role from user */
     discord_remove_guild_member_role(cogbot, primitives->guild_id,
                                      interaction->member->user->id,
-                                     primitives->roles.rubberduck_id, NULL);
+                                     primitives->roles.rubberduck_id, NULL, NULL);
 }
 
 static void
@@ -55,7 +55,7 @@ done_get_channel(struct discord *cogbot,
             NULL);
     }
     else {
-        discord_delete_channel(cogbot, channel->id,
+        discord_delete_channel(cogbot, channel->id, NULL,
                                &(struct discord_ret_channel){
                                    .done = &done_delete_channel,
                                    .fail = &fail_delete_channel,

--- a/interactions/rubberduck-channel/menu.c
+++ b/interactions/rubberduck-channel/menu.c
@@ -160,6 +160,7 @@ react_rubberduck_channel_menu(struct discord *cogbot,
     discord_add_guild_member_role(cogbot, primitives->guild_id,
                                   interaction->member->user->id,
                                   primitives->roles.rubberduck_id,
+                                  NULL,
                                   &(struct discord_ret){
                                       .done = &done_role_add,
                                       .fail = &fail_role_add,

--- a/interactions/select-roles/menu.c
+++ b/interactions/select-roles/menu.c
@@ -32,11 +32,11 @@ react_select_subscriptions_menu(struct discord *cogbot,
     if (is_reset) {
         discord_remove_guild_member_role(
             cogbot, interaction->guild_id, member->user->id,
-            primitives->roles.announcements_id, NULL);
+            primitives->roles.announcements_id, NULL, NULL);
 
         discord_remove_guild_member_role(cogbot, interaction->guild_id,
                                          member->user->id,
-                                         primitives->roles.watcher_id, NULL);
+                                         primitives->roles.watcher_id, NULL, NULL);
 
         params->data->content = "Your subscriptions have been reset";
     }
@@ -45,7 +45,7 @@ react_select_subscriptions_menu(struct discord *cogbot,
 
         for (int i = 0; roles[i] && i < arr_size; ++i) {
             discord_add_guild_member_role(cogbot, interaction->guild_id,
-                                          member->user->id, roles[i], NULL);
+                                          member->user->id, roles[i], NULL, NULL);
         }
 
         params->data->content = "Your subscriptions have been registered";
@@ -83,16 +83,16 @@ react_select_OS(struct discord *cogbot,
     if (is_reset) {
         discord_remove_guild_member_role(cogbot, interaction->guild_id,
                                          member->user->id,
-                                         primitives->roles.linux_id, NULL);
+                                         primitives->roles.linux_id, NULL, NULL);
         discord_remove_guild_member_role(cogbot, interaction->guild_id,
                                          member->user->id,
-                                         primitives->roles.windows_id, NULL);
+                                         primitives->roles.windows_id, NULL, NULL);
         discord_remove_guild_member_role(cogbot, interaction->guild_id,
                                          member->user->id,
-                                         primitives->roles.macos_id, NULL);
+                                         primitives->roles.macos_id, NULL, NULL);
         discord_remove_guild_member_role(cogbot, interaction->guild_id,
                                          member->user->id,
-                                         primitives->roles.bsd_id, NULL);
+                                         primitives->roles.bsd_id, NULL, NULL);
 
         params->data->content = "Your OS choice has been reset";
     }
@@ -101,7 +101,7 @@ react_select_OS(struct discord *cogbot,
 
         for (int i = 0; roles[i] && i < arr_size; ++i) {
             discord_add_guild_member_role(cogbot, interaction->guild_id,
-                                          member->user->id, roles[i], NULL);
+                                          member->user->id, roles[i], NULL, NULL);
         }
 
         params->data->content = "Your OS choice has been set";


### PR DESCRIPTION
## Notice
- [x] I *understand* the code that I have edited, and have the means
to test it before making changes to Concord.

## What?
This PR updates some Concord functions called in the bot, using the newest parameters.

## Why?
This allows the bot to be able to compile on newer versions of Concord.

## How?
By appending `NULL` as `params` in the functions.

## Testing?
Not done yet.